### PR TITLE
Add Cansat deployed and payload deploy flight modes

### DIFF
--- a/CanSat-code/CanSat-container/include/Cansat-modes.hpp
+++ b/CanSat-code/CanSat-container/include/Cansat-modes.hpp
@@ -1,54 +1,69 @@
 #pragma once
-
+#include <queue>
 #include "../include/container-dto.hpp"
+#include "../lib/ParachuteServo.hpp"
+#include "../lib/PayloadServo.hpp"
+
+ParachuteServo parachuteServo(36);
+PayloadServo payloadServo(37);
+
+#define PARACHUTE_DEPLOY_ALTITUDE 400
+#define PARACHUTE_DEPLOY_SAMPLE_COUNT 7
 
 namespace CanSat
 {
     class CanSatModes
     {
-
-    public:
-        static Container_Data PreFlight(Container_Data container_data)
-        {
-            return container_data;
-        }
-
-        static Container_Data Launched(Container_Data container_data)
-        {
-            return container_data;
-        }
-
-        static Container_Data CanSatDeployed(Container_Data container_data)
-        {
-            return container_data;
-        }
-
-        static Container_Data ParachuteDeploy(Container_Data container_data)
-        {
-            return container_data;
-        }
-
-        static Container_Data PayloadDeploy(Container_Data container_data)
-        {
-            return container_data;
-        }
-
-        static Container_Data SecondaryParachute(Container_Data container_data)
-        {
-            return container_data;
-        }
-
-        static Container_Data PayloadLanding(Container_Data container_data)
-        {
-            return container_data;
-        }
-
-        static Container_Data Land(Container_Data container_data)
-        {
-            return container_data;
-        }
-
     private:
+        static int parachuteThresholdMetCounter;
+    public:
+        static Container_Data PreFlight(Container_Data container_data) // flight mode 'U'
+        {
+            return container_data;
+        }
+
+        static Container_Data Launched(Container_Data container_data) // flight mode 'L'
+        {
+            return container_data;
+        }
+
+        static Container_Data CanSatDeployed(Container_Data container_data) // flight mode 'D'
+        {            
+            if (container_data.barometer_data.altitude < PARACHUTE_DEPLOY_ALTITUDE) {
+                parachuteThresholdMetCounter++;
+            } 
+            else {
+                parachuteThresholdMetCounter = 0;
+            }
+
+            if (parachuteThresholdMetCounter > PARACHUTE_DEPLOY_SAMPLE_COUNT){
+                container_data.flight_mode = 'S';
+            }
+
+            return container_data;
+        }
+
+        static Container_Data ParachuteDeploy(Container_Data container_data) // flight mode 'S'
+        {
+            return container_data;
+        }
+
+        static Container_Data PayloadDeploy(Container_Data container_data) // flight mode 'P'
+        {
+            payloadServo.ReleasePayload();
+            container_data.flight_mode = 'A';
+            return container_data;
+        }
+
+        static Container_Data PayloadLanding(Container_Data container_data) // flight mode 'A'
+        {
+            return container_data;
+        }
+
+        static Container_Data Land(Container_Data container_data) // flight mode 'G'
+        {
+            return container_data;
+        }
     };
 
 }

--- a/CanSat-code/CanSat-container/lib/ParachuteServo.hpp
+++ b/CanSat-code/CanSat-container/lib/ParachuteServo.hpp
@@ -1,0 +1,22 @@
+#include <Servo.h>
+#include <Arduino.h>
+namespace CanSat
+{
+    class ParachuteServo {
+        private:
+            Servo servo;
+            int position = 0;
+            bool open = false;
+        public:
+            ParachuteServo(int pin){
+                servo.attach(pin);
+                servo.write(0);
+            }
+            
+            void ReleaseParachute(){
+                servo.write(180);
+            }
+
+            
+    };
+} 

--- a/CanSat-code/CanSat-container/lib/PayloadServo.hpp
+++ b/CanSat-code/CanSat-container/lib/PayloadServo.hpp
@@ -1,0 +1,22 @@
+#include <Servo.h>
+#include <Arduino.h>
+namespace CanSat
+{
+    class PayloadServo {
+        private:
+            Servo servo;
+            int position = 0;
+            bool open = false;
+        public:
+            PayloadServo(int pin){
+                servo.attach(pin);
+                servo.write(0);
+            }
+            
+            void ReleasePayload(){
+                servo.write(180);
+            }
+
+            
+    };
+} 

--- a/CanSat-code/CanSat-container/platformio.ini
+++ b/CanSat-code/CanSat-container/platformio.ini
@@ -15,4 +15,5 @@ framework = arduino
 monitor_speed = 9600
 lib_deps = 
     Wire
+    Servo
     featherfly/SoftwareSerial@^1.0


### PR DESCRIPTION
Adds Cansat deployed and payload deploy flight modes and adds classes for the payload and parachute servos. Also, I left a queue import in the file, but I will remove it in the next push.