### PR TITLE
Swap xbee pins to correct one, cleans up a tiny bit

### DIFF
--- a/CanSat-code/CanSat-container/include/rules-engine.hpp
+++ b/CanSat-code/CanSat-container/include/rules-engine.hpp
@@ -24,7 +24,7 @@ namespace CanSat
             char modes[5] = {'U', 'L', 'D', 'S', 'G'};
             int current_mode = 0;
         public:
-            RulesEngine(XBEE &to_groundcontrol_)
+            RulesEngine()
             {
             }
 

--- a/CanSat-code/CanSat-container/src/main.cpp
+++ b/CanSat-code/CanSat-container/src/main.cpp
@@ -14,11 +14,11 @@ ModeSelect mode_select;
 MissionControlHandler mission_control_handler;
 Container_Data container_data;
 
-XBEE xbee(15, 14);
+XBEE xbee(14, 15);
 MPL3115A2 barometer(17, 16);
 MPU6050 IMU(18, 19);
 PA1616S GPS;
-RulesEngine rules_engine(xbee);
+RulesEngine rules_engine;
 
 String json_data = "";
 int heartbeat = 0;
@@ -33,7 +33,7 @@ Container_Data ReadAllSensors(Container_Data container_data){
     // Update all sensors
     barometer.Update();
     IMU.Update();
-    // GPS.Update();
+    GPS.Update();
 
     container_data.heartbeat_count = ++heartbeat;
 


### PR DESCRIPTION
Swaps xbee pins to get proper radio output.
Extra Clean up:
- Uncommented GPS update line
- Deleted leftover radio into rules engine (no more radio functs in rules engine)