### PR TITLE
:sparkles: adds demo creation to project

### DIFF
--- a/CanSat-code/CanSat-container/demos/README.md
+++ b/CanSat-code/CanSat-container/demos/README.md
@@ -1,6 +1,11 @@
-# Demos
+# Demo Creation and Execution
 Demos are a way to test the CanSat-container code for different devices. They are not meant to be used in the actual CanSat control system. If you want to create a new demo, you can use the template in the `demo-template` folder and copy the src folder and platformio.ini file to a new folder. Then you can start editing the code.
 
+## Pre-requisites
+To run and flash the demos you need to install platformio. You can install it by running the following command:
+```bash
+pip install -U platformio
+```
 
 ## Running and Uploading Demos
 To run the compile the demos run the following while in the desired demo folder:

--- a/CanSat-code/CanSat-container/demos/README.md
+++ b/CanSat-code/CanSat-container/demos/README.md
@@ -1,0 +1,14 @@
+# Demos
+Demos are a way to test the CanSat-container code for different devices. They are not meant to be used in the actual CanSat control system. If you want to create a new demo, you can use the template in the `demo-template` folder and copy the src folder and platformio.ini file to a new folder. Then you can start editing the code.
+
+
+## Running and Uploading Demos
+To run the compile the demos run the following while in the desired demo folder:
+```bash
+platformio run
+```
+
+To upload the code to the device run the following:
+```bash
+platformio run --target upload
+```

--- a/CanSat-code/CanSat-container/demos/camera_demo/platformio.ini
+++ b/CanSat-code/CanSat-container/demos/camera_demo/platformio.ini
@@ -1,0 +1,19 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:teensy41]
+platform = teensy
+board = teensy41
+framework = arduino
+monitor_speed = 9600
+lib_deps = 
+    Wire
+    Servo
+    featherfly/SoftwareSerial@^1.0

--- a/CanSat-code/CanSat-container/demos/camera_demo/src/main.cpp
+++ b/CanSat-code/CanSat-container/demos/camera_demo/src/main.cpp
@@ -1,0 +1,17 @@
+#include <Arduino.h>
+#include "../../../lib/MiniSpyCamera.hpp"
+using namespace CanSat;
+
+MiniSpyCamera camera(8);
+
+void setup() {
+  Serial.begin(9600);
+
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  Serial.println("Starting Camera Demo!");
+  camera.TakeImage();
+  camera.TakeVideo(5000);
+}

--- a/CanSat-code/CanSat-container/demos/demo-template/platformio.ini
+++ b/CanSat-code/CanSat-container/demos/demo-template/platformio.ini
@@ -1,0 +1,19 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:teensy41]
+platform = teensy
+board = teensy41
+framework = arduino
+monitor_speed = 9600
+lib_deps = 
+    Wire
+    Servo
+    featherfly/SoftwareSerial@^1.0

--- a/CanSat-code/CanSat-container/demos/demo-template/src/main.cpp
+++ b/CanSat-code/CanSat-container/demos/demo-template/src/main.cpp
@@ -1,0 +1,15 @@
+#include <Arduino.h>
+
+// using namespace CanSat; // This is not needed for this demo but is needed for the CanSat driver code for your devices
+// run platformio run to compile and platformio run --target upload to upload to your board
+
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(9600);
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  Serial.println("Hello World");
+  delay(1000);
+}


### PR DESCRIPTION
You can now add demos to the project. This makes testing out devices easier than running the main source code all the time. Read the README,md in the demos folder, so you know how to run the demos properly. I also left a template demo so you can copy the necessary folders for a new demo. All you need to do is include the required libraries for your demo, flash, and you can test 😄 . Happy testing!